### PR TITLE
Parse date and transfer type

### DIFF
--- a/src/components/App/App.test.tsx
+++ b/src/components/App/App.test.tsx
@@ -26,40 +26,50 @@ describe("App", () => {
         <App />
       </Router>
     );
-    const bellerinTransfersCards = screen.getAllByRole("heading", {
-      name: /héctor bellerín/i,
-    });
-    const transferCard: HTMLElement = bellerinTransfersCards[0].parentElement
-      ?.parentElement as HTMLElement;
-    const transferDate: HTMLElement =
-      within(transferCard).getByText("2022-07-01");
-    const transferType: HTMLElement =
-      within(transferCard).getByText("Fin de contrato");
-    const transferInContainer = within(transferCard).getByText("Baja")
-      .parentElement?.parentElement as HTMLElement;
-    const transferOutContainer = within(transferCard).getByText("Alta")
-      .parentElement?.parentElement as HTMLElement;
-    const transferOutTeamLogo =
-      within(transferCard).getByAltText("Logo de Real Betis");
-    const transferInTeamLogo =
-      within(transferCard).getByAltText("Logo de Arsenal");
-    const transferInTeamName =
-      within(transferInContainer).getByText("Real Betis");
-    const transferOutTeamName =
-      within(transferOutContainer).getByText("Arsenal");
 
-    expect(transferCard).toBeVisible();
-    expect(transferDate).toBeVisible();
-    expect(transferType).toBeVisible();
-    expect(transferInTeamName).toBeVisible();
-    expect(transferOutTeamName).toBeVisible();
-    expect(transferOutTeamLogo).toHaveAttribute(
+    const card: HTMLElement = screen.getAllByRole("heading", {
+      name: /alexandre moreno lopera/i,
+    })[0].parentElement?.parentElement as HTMLElement;
+    const heading: HTMLElement = within(card).getByRole("heading", {
+      name: /alexandre moreno lopera/i,
+    });
+    const date: HTMLElement = within(card).getAllByRole(
+      "listitem"
+    )[0] as HTMLElement;
+    const type: HTMLElement = within(card).getAllByRole(
+      "listitem"
+    )[1] as HTMLElement;
+    const outTeamContainer = within(card).getByText("Baja").parentElement
+      ?.parentElement as HTMLElement;
+    const outTeamLogo = within(outTeamContainer).getByAltText(
+      "Logo de Rayo Vallecano"
+    );
+    const outTeamName = within(outTeamContainer).getByText("Rayo Vallecano");
+    const inTeamContainer = within(card).getByText("Alta").parentElement
+      ?.parentElement as HTMLElement;
+    const inTeamLogo =
+      within(inTeamContainer).getByAltText("Logo de Real Betis");
+    const inTeamName = within(inTeamContainer).getByText("Real Betis");
+
+    expect(card).toBeVisible();
+    expect(heading).toBeVisible();
+    expect(heading).toHaveTextContent("Alexandre Moreno Lopera");
+    expect(date).toBeVisible();
+    expect(date).toHaveTextContent("21/08/2019");
+    expect(date).toBeVisible();
+    expect(type).toBeVisible();
+    expect(type).toHaveTextContent("€ 7.5M");
+    expect(outTeamName).toBeVisible();
+    expect(outTeamName).toHaveTextContent("Rayo Vallecano");
+    expect(outTeamLogo).toHaveAttribute(
+      "src",
+      "https://media.api-sports.io/football/teams/728.png"
+    );
+    expect(inTeamName).toBeVisible();
+    expect(inTeamName).toHaveTextContent("Real Betis");
+    expect(inTeamLogo).toHaveAttribute(
       "src",
       "https://media.api-sports.io/football/teams/543.png"
-    );
-    expect(transferInTeamLogo).toHaveAttribute(
-      "src",
-      "https://media.api-sports.io/football/teams/42.png"
     );
   });
 

--- a/src/components/App/App.test.tsx
+++ b/src/components/App/App.test.tsx
@@ -33,7 +33,8 @@ describe("App", () => {
       ?.parentElement as HTMLElement;
     const transferDate: HTMLElement =
       within(transferCard).getByText("2022-07-01");
-    const transferType: HTMLElement = within(transferCard).getByText("N/A");
+    const transferType: HTMLElement =
+      within(transferCard).getByText("Fin de contrato");
     const transferInContainer = within(transferCard).getByText("Baja")
       .parentElement?.parentElement as HTMLElement;
     const transferOutContainer = within(transferCard).getByText("Alta")
@@ -47,15 +48,10 @@ describe("App", () => {
     const transferOutTeamName =
       within(transferOutContainer).getByText("Arsenal");
 
-    expect(transferCard).toBeInTheDocument();
     expect(transferCard).toBeVisible();
-    expect(transferDate).toBeInTheDocument();
     expect(transferDate).toBeVisible();
-    expect(transferType).toBeInTheDocument();
     expect(transferType).toBeVisible();
-    expect(transferInTeamName).toBeInTheDocument();
     expect(transferInTeamName).toBeVisible();
-    expect(transferOutTeamName).toBeInTheDocument();
     expect(transferOutTeamName).toBeVisible();
     expect(transferOutTeamLogo).toHaveAttribute(
       "src",

--- a/src/components/TransfersList/Transfer/Transfer.component.tsx
+++ b/src/components/TransfersList/Transfer/Transfer.component.tsx
@@ -17,7 +17,7 @@ const Transfer = ({ transfer }: TransferProps): JSX.Element => {
       </section>
       <section className="transfer-info">
         <ul>
-          <li>{transfer.date.toLocaleString()}</li>
+          <li>{new Date(transfer.date).toLocaleDateString()}</li>
           <li>{parseTransferType(transfer.type)}</li>
         </ul>
         <div className="team-info">

--- a/src/components/TransfersList/Transfer/Transfer.component.tsx
+++ b/src/components/TransfersList/Transfer/Transfer.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ClientTransfer } from "interfaces/ClientTransfer";
+import { parseTransferType } from "utils/utils";
 
 type TransferProps = {
   transfer: ClientTransfer;
@@ -14,7 +15,7 @@ const Transfer = ({ transfer }: TransferProps): JSX.Element => {
       <section className="transfer-info">
         <ul>
           <li>{transfer.date.toLocaleString()}</li>
-          <li>{transfer.type}</li>
+          <li>{parseTransferType(transfer.type)}</li>
         </ul>
         <div className="team-info">
           <header>

--- a/src/components/TransfersList/Transfer/Transfer.component.tsx
+++ b/src/components/TransfersList/Transfer/Transfer.component.tsx
@@ -7,6 +7,9 @@ type TransferProps = {
 };
 
 const Transfer = ({ transfer }: TransferProps): JSX.Element => {
+  if (transfer.playerName === "Data not available") {
+    return <></>;
+  }
   return (
     <article aria-label="transfer-card">
       <section className="player-name">

--- a/src/components/TransfersList/Transfer/Transfer.test.tsx
+++ b/src/components/TransfersList/Transfer/Transfer.test.tsx
@@ -70,4 +70,42 @@ describe("Transfer", () => {
       "https://media.api-sports.io/football/teams/543.png"
     );
   });
+
+  it("does not shows a card when player name is 'Data not available'", () => {
+    const history = createMemoryHistory({ initialEntries: ["/"] });
+    const transfer = {
+      date: "2020-01-27",
+      type: "Free",
+      teams: {
+        in: {
+          id: 543,
+          name: "Real Betis",
+          logo: "https://media.api-sports.io/football/teams/543.png",
+        },
+        out: {
+          id: 1876,
+          name: "Tavagnacco W",
+          logo: "https://media.api-sports.io/football/teams/1876.png",
+        },
+      },
+      playerName: "Data not available",
+      playerId: 90315,
+      season: "2020",
+    };
+    render(
+      <Router location={history.location} navigator={history}>
+        <Transfer transfer={transfer} />
+      </Router>
+    );
+
+    const card = screen.queryByRole("article", { name: "transfer-card" });
+    const heading = screen.queryByRole("heading", {
+      name: "Data not available",
+    });
+
+    expect(card).not.toBeInTheDocument();
+    expect(card).toBeNull();
+    expect(heading).not.toBeInTheDocument();
+    expect(heading).toBeNull();
+  });
 });

--- a/src/components/TransfersList/Transfer/Transfer.test.tsx
+++ b/src/components/TransfersList/Transfer/Transfer.test.tsx
@@ -10,7 +10,7 @@ describe("Transfer", () => {
     const history = createMemoryHistory({ initialEntries: ["/"] });
     const transfer = {
       date: "2021-08-20",
-      type: "€ 4M",
+      type: "N/A",
       teams: {
         in: {
           id: 543,
@@ -58,7 +58,7 @@ describe("Transfer", () => {
     expect(date).toBeVisible();
     expect(date).toHaveTextContent("2021-08-20");
     expect(transferType).toBeVisible();
-    expect(transferType).toHaveTextContent("€ 4M");
+    expect(transferType).toHaveTextContent("Fin de contrato");
     expect(transferInTeamName).toBeVisible();
     expect(transferOutTeamName).toBeVisible();
     expect(transferOutTeamLogo).toHaveAttribute(

--- a/src/components/TransfersList/Transfer/Transfer.test.tsx
+++ b/src/components/TransfersList/Transfer/Transfer.test.tsx
@@ -56,7 +56,7 @@ describe("Transfer", () => {
     expect(card).toBeVisible();
     expect(heading).toBeVisible();
     expect(date).toBeVisible();
-    expect(date).toHaveTextContent("2021-08-20");
+    expect(date).toHaveTextContent("20/08/2021");
     expect(transferType).toBeVisible();
     expect(transferType).toHaveTextContent("Fin de contrato");
     expect(transferInTeamName).toBeVisible();

--- a/src/components/TransfersList/TransfersList.test.tsx
+++ b/src/components/TransfersList/TransfersList.test.tsx
@@ -16,7 +16,7 @@ describe("TransfersList", () => {
       </Router>
     );
     const articles = screen.getAllByRole("article");
-    expect(articles).toHaveLength(445);
+    expect(articles).toHaveLength(444);
   });
 
   it("shows 5 articles when a season is passed", () => {

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,40 @@
+import { parseTransferType } from "utils/utils";
+
+describe("utils", () => {
+  describe("parseTransferType", () => {
+    it("should return 'No disponible' when type is null'", async () => {
+      const typeToTest = null;
+      const typeReturned = parseTransferType(typeToTest);
+
+      expect(typeReturned).toBe("No disponible");
+    });
+  });
+
+  it("should return 'Fin de contrato' when type is 'N/A'", async () => {
+    const typeToTest = "N/A";
+    const typeReturned = parseTransferType(typeToTest);
+
+    expect(typeReturned).toBe("Fin de contrato");
+  });
+
+  it("should return 'Cesión' when type is 'Loan'", async () => {
+    const typeToTest = "Loan";
+    const typeReturned = parseTransferType(typeToTest);
+
+    expect(typeReturned).toBe("Cesión");
+  });
+
+  it("should return 'Libre' when type is 'Free'", async () => {
+    const typeToTest = "Free";
+    const typeReturned = parseTransferType(typeToTest);
+
+    expect(typeReturned).toBe("Libre");
+  });
+
+  it("should return 'Libre' when type is '€ Free'", async () => {
+    const typeToTest = "€ Free";
+    const typeReturned = parseTransferType(typeToTest);
+
+    expect(typeReturned).toBe("Libre");
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,15 @@
+export const parseTransferType = (type: string | null) => {
+  if (type === null) {
+    return "No disponible";
+  }
+  if (type === "N/A") {
+    return "Fin de contrato";
+  }
+  if (type === "Loan") {
+    return "Cesión";
+  }
+  if (type === "Free" || type === "€ Free") {
+    return "Libre";
+  }
+  return type;
+};


### PR DESCRIPTION
We had problems with API data received for date and type, so we made some changes in our code to parse them.

### Date

We parse `date` property to show it with `toLocaleDateString()` format.

### Type

We changed the four `type` bad properties received to:

- From `null` to `No disponible`.
- From `N/A` to `Fin de contrato`.
- From `Loan` to `Cesión`.
- From `Free` to `Libre`.
- From `€ Free` to `Libre`.